### PR TITLE
Fixed package.json exports to allow for imports of Single Clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ package-lock.json
 dist/
 
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
-
+# 
 # dependencies
 /node_modules
 /.pnp

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
         ".": {
             "import": "./dist/index.mjs",
             "require": "./dist/index.cjs"
+        },
+        "./scopes": {
+            "import": "./dist/scopes/index.mjs",
+            "require": "./dist/scopes/index.cjs"
         }
     },
     "scripts": {


### PR DESCRIPTION
# Title Says it all


the export for the Single client was missing from package.json 
### Before
```json
"exports": {
        ".": {
            "import": "./dist/index.mjs",
            "require": "./dist/index.cjs"
        },
    },
```
### After
```json
"exports": {
        ".": {
            "import": "./dist/index.mjs",
            "require": "./dist/index.cjs"
        },
        "./scopes": {
            "import": "./dist/scopes/index.mjs",
            "require": "./dist/scopes/index.cjs"
        }
    },
```